### PR TITLE
Setting

### DIFF
--- a/checkpoint-time/play-cm-runCheck.sh
+++ b/checkpoint-time/play-cm-runCheck.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# 컨테이너 실행
+sudo podman run -dt --name changedMemory -it cm
+sudo podman ps
+
+# 현재 시간을 초로 변환
+start_time=$(date +%s)
+
+# 'pre-checkpoint' 명령어 실행
+sudo podman container checkpoint --print-stats --pre-checkpoint changedMemory
+
+# 60초 후까지 대기
+while true; do
+    current_time=$(date +%s)
+    elapsed_time=$((current_time - start_time))
+    if [ "$elapsed_time" -ge 60 ]; then
+        break
+    fi
+    sleep 1
+done
+
+# 'pre-checkpoint' 명령어 실행
+sudo podman container checkpoint --print-stats --pre-checkpoint changedMemory
+
+# 120초 후까지 대기
+while true; do
+    current_time=$(date +%s)
+    elapsed_time=$((current_time - start_time))
+    if [ "$elapsed_time" -ge 120 ]; then
+        break
+    fi
+    sleep 1
+done
+
+# 'pre-checkpoint' 명령어 실행
+sudo podman container checkpoint --print-stats --pre-checkpoint changedMemory
+
+# 180초 후까지 대기
+while true; do
+    current_time=$(date +%s)
+    elapsed_time=$((current_time - start_time))
+    if [ "$elapsed_time" -ge 180 ]; then
+        break
+    fi
+    sleep 1
+done
+
+# 'pre-checkpoint' 명령어 실행
+sudo podman container checkpoint --print-stats --pre-checkpoint changedMemory
+
+# 240초 후까지 대기
+while true; do
+    current_time=$(date +%s)
+    elapsed_time=$((current_time - start_time))
+    if [ "$elapsed_time" -ge 240 ]; then
+        break
+    fi
+    sleep 1
+done
+
+# 'pre-checkpoint' 명령어 실행
+sudo podman container checkpoint --print-stats --pre-checkpoint changedMemory
+sudo podman stop changedMemory
+
+# 실험 종료 후 컨테이너 삭제
+sudo podman rm changedMemory

--- a/checkpoint-time/play-notCM-runCheck.sh
+++ b/checkpoint-time/play-notCM-runCheck.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# 컨테이너 실행
+sudo podman run -dt --name notChangedMemory -it notcm
+sudo podman ps
+
+# 현재 시간을 초로 변환
+start_time=$(date +%s)
+
+# 'pre-checkpoint' 명령어 실행
+sudo podman container checkpoint --print-stats --pre-checkpoint notChangedMemory
+
+# 60초 후까지 대기
+while true; do
+    current_time=$(date +%s)
+    elapsed_time=$((current_time - start_time))
+    if [ "$elapsed_time" -ge 60 ]; then
+        break
+    fi
+    sleep 1
+done
+
+# 'pre-checkpoint' 명령어 실행
+sudo podman container checkpoint --print-stats --pre-checkpoint notChangedMemory
+
+# 120초 후까지 대기
+while true; do
+    current_time=$(date +%s)
+    elapsed_time=$((current_time - start_time))
+    if [ "$elapsed_time" -ge 120 ]; then
+        break
+    fi
+    sleep 1
+done
+
+# 'pre-checkpoint' 명령어 실행
+sudo podman container checkpoint --print-stats --pre-checkpoint notChangedMemory
+
+# 180초 후까지 대기
+while true; do
+    current_time=$(date +%s)
+    elapsed_time=$((current_time - start_time))
+    if [ "$elapsed_time" -ge 180 ]; then
+        break
+    fi
+    sleep 1
+done
+
+# 'pre-checkpoint' 명령어 실행
+sudo podman container checkpoint --print-stats --pre-checkpoint notChangedMemory
+
+# 240초 후까지 대기
+while true; do
+    current_time=$(date +%s)
+    elapsed_time=$((current_time - start_time))
+    if [ "$elapsed_time" -ge 240 ]; then
+        break
+    fi
+    sleep 1
+done
+
+# 'pre-checkpoint' 명령어 실행
+sudo podman container checkpoint --print-stats --pre-checkpoint notChangedMemory
+sudo podman stop notChangedMemory
+
+# 실험 종료 후 컨테이너 삭제
+sudo podman rm notChangedMemory

--- a/checkpoint-time/play-os-runCheck.sh
+++ b/checkpoint-time/play-os-runCheck.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# 컨테이너 실행
+sudo podman run -dt --name osImage -it ubuntu
+sudo podman ps
+
+# 현재 시간을 초로 변환
+start_time=$(date +%s)
+
+# 'pre-checkpoint' 명령어 실행
+sudo podman container checkpoint --print-stats --pre-checkpoint osImage
+
+# 60초 후까지 대기
+while true; do
+    current_time=$(date +%s)
+    elapsed_time=$((current_time - start_time))
+    if [ "$elapsed_time" -ge 60 ]; then
+        break
+    fi
+    sleep 1
+done
+
+# 'pre-checkpoint' 명령어 실행
+sudo podman container checkpoint --print-stats --pre-checkpoint osImage
+
+# 120초 후까지 대기
+while true; do
+    current_time=$(date +%s)
+    elapsed_time=$((current_time - start_time))
+    if [ "$elapsed_time" -ge 120 ]; then
+        break
+    fi
+    sleep 1
+done
+
+# 'pre-checkpoint' 명령어 실행
+sudo podman container checkpoint --print-stats --pre-checkpoint osImage
+
+# 180초 후까지 대기
+while true; do
+    current_time=$(date +%s)
+    elapsed_time=$((current_time - start_time))
+    if [ "$elapsed_time" -ge 180 ]; then
+        break
+    fi
+    sleep 1
+done
+
+# 'pre-checkpoint' 명령어 실행
+sudo podman container checkpoint --print-stats --pre-checkpoint osImage
+
+# 240초 후까지 대기
+while true; do
+    current_time=$(date +%s)
+    elapsed_time=$((current_time - start_time))
+    if [ "$elapsed_time" -ge 240 ]; then
+        break
+    fi
+    sleep 1
+done
+
+# 'pre-checkpoint' 명령어 실행
+sudo podman container checkpoint --print-stats --pre-checkpoint osImage
+sudo podman stop osImage
+
+# 실험 종료 후 컨테이너 삭제
+sudo podman rm osImage

--- a/pre-checkpoint-container/play-restore.sh
+++ b/pre-checkpoint-container/play-restore.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# 컨테이너 실행
+sudo podman run -dt --name calculation -it calc
+sudo podman ps
+
+# 현재 시간을 초로 변환
+start_time=$(date +%s)
+
+# 60초 후까지 대기
+while true; do
+    current_time=$(date +%s)
+    elapsed_time=$((current_time - start_time))
+    if [ "$elapsed_time" -ge 60 ]; then
+        break
+    fi
+    sleep 1
+done
+
+# 'pre-checkpoint' 명령어 실행
+sudo podman container checkpoint --print-stats --pre-checkpoint calculation
+sudo podman logs calculation
+
+# 180초 후까지 대기
+while true; do
+    current_time=$(date +%s)
+    elapsed_time=$((current_time - start_time))
+    if [ "$elapsed_time" -ge 180 ]; then
+        break
+    fi
+    sleep 1
+done
+
+# '복원용 체크포인트 생성' 명령어 실행
+sudo podman logs calculation
+sudo podman container checkpoint --with-previous calculation
+
+sudo podman container restore calculation
+sudo podman logs calculation
+
+# 컨테이너 실행 중단
+sudo podman stop calculation
+
+# 실험 종료 후 컨테이너 삭제
+#sudo podman rm calculation

--- a/pre-checkpoint-dump/3_setting.sh
+++ b/pre-checkpoint-dump/3_setting.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# 기존에 존재하는 images 목록을 전부 삭제한다.
+echo -e "\n존재하는 모든 이미지를 삭제합니다."
+sudo podman rm -a
+sudo podman rmi -a
+
+# container 이미지를 생성한다.
+echo -e "\ncheckpoint-time 실험에 필요한 이미지를 생성합니다."
+sudo podman build -t python -f Dockerfile-python . &> /dev/null
+sudo podman pull docker.io/tensorflow/tensorflow:latest &> /dev/null
+sudo podman build -t dump -f Dockerfile-dump . &> /dev/null
+echo -e "필요한 이미지를 모두 생성했습니다."
+
+# 생성한 images 목록을 확인한다.
+echo -e "\n설치된 이미지 목록을 확인합니다."
+sudo podman images

--- a/pre-checkpoint-dump/Dockerfile-dump
+++ b/pre-checkpoint-dump/Dockerfile-dump
@@ -1,0 +1,10 @@
+# 사용할 베이스 이미지를 선택합니다.
+FROM tensorflow/tensorflow:latest
+
+# 컨테이너 내에서 작업 디렉토리를 설정합니다.
+WORKDIR /play
+
+COPY ./dumping.py /play
+
+# 애플리케이션을 실행합니다.
+CMD [ "python3", "dumping.py" ]

--- a/pre-checkpoint-dump/Dockerfile-python
+++ b/pre-checkpoint-dump/Dockerfile-python
@@ -1,0 +1,19 @@
+# 사용할 베이스 이미지를 선택합니다. 여기서는 Ubuntu 기반의 이미지를 사용합니다.
+FROM ubuntu:22.04
+
+# 환경 변수 설정
+ENV DEBIAN_FRONTEND=noninteractive
+
+# 운영체제 업데이트 및 필요한 패키지 설치
+RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-pip
+
+# 파이썬 패키지 업그레이드
+RUN pip3 install --upgrade pip
+
+# 도커 컨테이너 내에서 Python을 사용할 수 있도록 환경을 설정합니다.
+ENV PATH="/usr/local/bin:${PATH}"
+
+# 컨테이너 시작 시 파이썬 쉘을 실행
+CMD ["python3"]

--- a/pre-checkpoint-dump/dumping.py
+++ b/pre-checkpoint-dump/dumping.py
@@ -1,0 +1,38 @@
+import tensorflow as tf
+print("TensorFlow version:", tf.__version__)
+
+mnist = tf.keras.datasets.mnist
+
+(x_train, y_train), (x_test, y_test) = mnist.load_data()
+x_train, x_test = x_train / 255.0, x_test / 255.0
+
+model = tf.keras.models.Sequential([
+  tf.keras.layers.Flatten(input_shape=(28, 28)),
+  tf.keras.layers.Dense(128, activation='relu'),
+  tf.keras.layers.Dropout(0.2),
+  tf.keras.layers.Dense(10, activation='softmax')
+])
+
+model.compile(optimizer='adam',
+              loss='sparse_categorical_crossentropy',
+              metrics=['accuracy'])
+
+predictions = model(x_train[:1]).numpy()
+predictions
+
+tf.nn.softmax(predictions).numpy()
+
+loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)
+loss_fn(y_train[:1], predictions).numpy()
+
+model.compile(optimizer='adam',
+              loss=loss_fn,
+              metrics=['accuracy'])
+
+
+
+model.fit(x_train, y_train, epochs=50)
+
+model.evaluate(x_test,  y_test, verbose=2)
+
+ing = input("")

--- a/pre-checkpoint-dump/play-dump-runCheck.sh
+++ b/pre-checkpoint-dump/play-dump-runCheck.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# 컨테이너 실행
+sudo podman run -dt --name dumping -it dump
+sudo podman ps
+
+# 현재 시간을 초로 변환
+start_time=$(date +%s)
+
+# 'pre-checkpoint' 명령어 실행
+sudo podman container checkpoint --print-stats --pre-checkpoint dumping
+
+# 60초 후까지 대기
+while true; do
+    current_time=$(date +%s)
+    elapsed_time=$((current_time - start_time))
+    if [ "$elapsed_time" -ge 60 ]; then
+        break
+    fi
+    sleep 1
+done
+
+# 'pre-checkpoint' 명령어 실행
+sudo podman container checkpoint --print-stats --pre-checkpoint dumping
+
+# 120초 후까지 대기
+while true; do
+    current_time=$(date +%s)
+    elapsed_time=$((current_time - start_time))
+    if [ "$elapsed_time" -ge 120 ]; then
+        break
+    fi
+    sleep 1
+done
+
+# 'pre-checkpoint' 명령어 실행
+sudo podman container checkpoint --print-stats --pre-checkpoint dumping
+
+# 180초 후까지 대기
+while true; do
+    current_time=$(date +%s)
+    elapsed_time=$((current_time - start_time))
+    if [ "$elapsed_time" -ge 180 ]; then
+        break
+    fi
+    sleep 1
+done
+
+# 'pre-checkpoint' 명령어 실행
+sudo podman container checkpoint --print-stats --pre-checkpoint dumping
+
+# 240초 후까지 대기
+while true; do
+    current_time=$(date +%s)
+    elapsed_time=$((current_time - start_time))
+    if [ "$elapsed_time" -ge 240 ]; then
+        break
+    fi
+    sleep 1
+done
+
+# 'pre-checkpoint' 명령어 실행
+sudo podman container checkpoint --print-stats --pre-checkpoint dumping
+sudo podman stop dumping
+
+# 실험 종료 후 컨테이너 삭제
+sudo podman rm dumping

--- a/pre-checkpoint-dump/play-dump.sh
+++ b/pre-checkpoint-dump/play-dump.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# 컨테이너 실행
+sudo podman run -dt --name dumping -it dump
+sudo podman ps
+
+# 현재 시간을 초로 변환
+start_time=$(date +%s)
+
+# 60초 후까지 대기
+while true; do
+    current_time=$(date +%s)
+    elapsed_time=$((current_time - start_time))
+    if [ "$elapsed_time" -ge 60 ]; then
+        break
+    fi
+    sleep 1
+done
+
+# 'pre-checkpoint' 명령어 실행
+sudo podman container checkpoint --print-stats --pre-checkpoint dumping
+
+# 120초 후까지 대기
+while true; do
+    current_time=$(date +%s)
+    elapsed_time=$((current_time - start_time))
+    if [ "$elapsed_time" -ge 120 ]; then
+        break
+    fi
+    sleep 1
+done
+
+# 'pre-checkpoint' 명령어 실행
+sudo podman container checkpoint --print-stats --pre-checkpoint dumping
+
+# 180초 후까지 대기
+while true; do
+    current_time=$(date +%s)
+    elapsed_time=$((current_time - start_time))
+    if [ "$elapsed_time" -ge 180 ]; then
+        break
+    fi
+    sleep 1
+done
+
+# 'pre-checkpoint' 명령어 실행
+sudo podman container checkpoint --print-stats --pre-checkpoint dumping
+
+# 240초 후까지 대기
+while true; do
+    current_time=$(date +%s)
+    elapsed_time=$((current_time - start_time))
+    if [ "$elapsed_time" -ge 240 ]; then
+        break
+    fi
+    sleep 1
+done
+
+# 'pre-checkpoint' 명령어 실행
+sudo podman container checkpoint --print-stats --pre-checkpoint dumping
+sudo podman stop dumping
+
+# 실험 종료 후 컨테이너 삭제
+sudo podman rm dumping


### PR DESCRIPTION
11/9일 실험을 위한 환경세팅
- [ ]  메모리 사용에 변동이 있는 워크로드를 강제로 종료시켜 메모리 변동이 없는 환경을 만들어서 이때의 프리-체크포인트 차이를 확인해보기
- [ ]  같은 내용의 파일이지만, 진행도가 다를 경우에 위의 옵션을 통해 복원이 가능한지 확인해보기
- [ ]  컨테이너를 실행하자마자 프리-체크포인트를 진행한다면?
    - 프리-체크포인트를 나중에 진행할 때보다 덤프 사이즈의 용량이 커지는 것 같다.
    - 각 환경에서 확인해보는 것이 좋을 듯하다.
    
- [ ] 파드맨 --pre-checkpoint 옵션을 사용했을 때, 컨테이너의 변화
    - 컨테이너가 stop 되었다가 start 하는 것을 파드맨이 자체적으로 하는 것인지.